### PR TITLE
#76/skip problematic rows

### DIFF
--- a/pygypsy/data_prep.py
+++ b/pygypsy/data_prep.py
@@ -36,6 +36,7 @@ from pygypsy.asaCompileAgeGivenSpSiHt import (
     ComputeGypsyTreeHeightGivenSiteIndexAndTotalAge,
     ComputeGypsySiteIndex,
 )
+from pygypsy.exceptions import MinimumAgeError, ProportionsSumError
 
 
 LOGGER = logging.getLogger(__name__)
@@ -63,6 +64,8 @@ def _populate_species_dict_with_indices(species_dict, estimated_site_indices):
     return local_species_dict
 
 
+# TODO: this is a bit deep in the stack to use the pandas data structure
+# should refactor in future. instead pass tph and bph as args
 def populate_species_dict(partial_species_list,
                           sorted_species_abbrev_perc_tuples_list,
                           dominant_species=None, row=None,
@@ -125,7 +128,186 @@ def populate_species_dict(partial_species_list,
     return species_dict
 
 
-def prep_standtable(data, minimum_age=25):
+def _prep_row(row, minimum_age=25):
+    '''Estimate properties required for gypsy simulation
+
+    :param row: row of data frame
+    :param minimum age: age below which plot should be skipped
+
+    :raises ProportionsSumError: if species proportions do not add to 1
+    :raises MinimumAgeError: if plot is less than minimum age
+
+    '''
+    species_abbrev_percent_list = [
+        (row['SP1'], row['PCT1']),
+        (row['SP2'], row['PCT2']),
+        (row['SP3'], row['PCT3']),
+        (row['SP4'], row['PCT4']),
+        (row['SP5'], row['PCT5'])
+    ]
+    plot_dominant_species = row['SP1']
+    dominant_species_current_age = row['AGE']
+    dominant_species_current_height = row['HD']
+
+    check_prop = sum(zip(*species_abbrev_percent_list)[1])
+    if check_prop != 100:
+        raise ProportionsSumError(
+            'Species proportions do not add to 1: %s' % check_prop
+        )
+
+    if dominant_species_current_age < minimum_age:
+        msg = ('Dominant species age is less than minimum age %s;'
+               'skipping plot %s') % (minimum_age, row['id_l1'])
+        raise MinimumAgeError(msg)
+
+    site_index = _estimate_site_index(
+        plot_dominant_species,
+        dominant_species_current_age,
+        dominant_species_current_height
+    )
+
+    temp_dominant_species = _get_gypsy_valid_species(plot_dominant_species)
+    gypsy_site_indices = get_site_indices_from_dominant_species(
+        temp_dominant_species,
+        site_index
+    )
+    empty_species_dict = _generate_fplot_dict()
+    species_dict = _populate_species_dict_with_indices(empty_species_dict,
+                                                       gypsy_site_indices)
+
+    outer_sorted_species_perc_list, outer_species_perc_dict = \
+        _reclassify_and_sort_species(species_abbrev_percent_list)
+
+    species_dict['Aw']['PCT'] = outer_species_perc_dict['Aw']
+    species_dict['Pl']['PCT'] = outer_species_perc_dict['Pl']
+    species_dict['Sw']['PCT'] = outer_species_perc_dict['Sw']
+    species_dict['Sb']['PCT'] = outer_species_perc_dict['Sb']
+
+    dominant_species = outer_sorted_species_perc_list[0]
+
+    species_dict = populate_species_dict(
+        species_dict, outer_sorted_species_perc_list,
+        dominant_species=dominant_species,
+        row=row,
+        dominant_species_current_age=dominant_species_current_age,
+        dominant_species_current_height=dominant_species_current_height
+    )
+
+    density_aw = species_dict['Aw']['N']
+    density_sw = species_dict['Sw']['N']
+    density_pl = species_dict['Pl']['N']
+    density_sb = species_dict['Sb']['N']
+    tage_aw = species_dict['Aw']['tage']
+    tage_sw = species_dict['Sw']['tage']
+    tage_pl = species_dict['Pl']['tage']
+    tage_sb = species_dict['Sb']['tage']
+    bhage_aw = species_dict['Aw']['bhage']
+    bhage_sw = species_dict['Sw']['bhage']
+    bhage_pl = species_dict['Pl']['bhage']
+    bhage_sb = species_dict['Sb']['bhage']
+    y2bh_aw = tage_aw - bhage_aw
+    y2bh_sw = tage_sw - bhage_sw
+    y2bh_pl = tage_pl - bhage_pl
+    y2bh_sb = tage_sb - bhage_sb
+    site_index_aw = species_dict['Aw']['SI']
+    site_index_sw = species_dict['Sw']['SI']
+    site_index_pl = species_dict['Pl']['SI']
+    site_index_sb = species_dict['Sb']['SI']
+    basal_area_aw = species_dict['Aw']['BA']
+    basal_area_sb = species_dict['Sb']['BA']
+    basal_area_sw = species_dict['Sw']['BA']
+    basal_area_pl = species_dict['Pl']['BA']
+
+    top_height_aw = ComputeGypsyTreeHeightGivenSiteIndexAndTotalAge(
+        'Aw', site_index_aw, tage_aw
+    )
+    top_height_sb = ComputeGypsyTreeHeightGivenSiteIndexAndTotalAge(
+        'Sb', site_index_sb, tage_sb
+    )
+    top_height_pl = ComputeGypsyTreeHeightGivenSiteIndexAndTotalAge(
+        'Pl', site_index_pl, tage_pl
+    )
+    top_height_sw = ComputeGypsyTreeHeightGivenSiteIndexAndTotalAge(
+        'Sw', site_index_sw, tage_sw
+    )
+    density_bh_aw, sdf_aw0 = estimate_sdf_aw(
+        'Aw', site_index_aw, bhage_aw, density_aw
+    )
+    density_bh_sb, sdf_sb0 = estimate_sdf_sb(
+        'Sb', site_index_sb, tage_sb, density_sb
+    )
+    density_bh_sw, sdf_sw0 = estimate_sdf_sw(
+        'Sw', site_index_sw, tage_sw, sdf_aw0, density_sw
+    )
+    density_bh_pl, sdf_pl0 = estimate_sdf_pl(
+        'Pl', site_index_pl, tage_pl,
+        sdf_aw0, sdf_sw0, sdf_sb0, density_pl
+    )
+
+    initial_density_aw = estimate_density_aw(
+        sdf_aw0, 0, site_index_aw
+    )
+    initial_density_sb = estimate_density_sb(
+        sdf_sb0, 0, site_index_sb
+    )
+    initial_density_sw = estimate_density_sw(
+        sdf_sw0, sdf_aw0, 0, site_index_sw
+    )
+    initial_density_pl = estimate_density_pl(
+        sdf_aw0, sdf_sw0, sdf_sb0, sdf_pl0, 0, site_index_pl
+    )
+
+    plot_properties = {
+        'SI_Aw': site_index_aw,
+        'SI_Sw': site_index_sw,
+        'SI_Pl': site_index_pl,
+        'SI_Sb': site_index_sb,
+        'N_Aw': density_aw,
+        'N_Sw': density_sw,
+        'N_Pl': density_pl,
+        'N_Sb': density_sb,
+        'y2bh_Aw': y2bh_aw,
+        'y2bh_Sw': y2bh_sw,
+        'y2bh_Pl': y2bh_pl,
+        'y2bh_Sb': y2bh_sb,
+        'tage_Aw': tage_aw,
+        'tage_Sw': tage_sw,
+        'tage_Pl': tage_pl,
+        'tage_Sb': tage_sb,
+        'BA_Aw': basal_area_aw,
+        'BA_Sw': basal_area_sw,
+        'BA_Pl': basal_area_pl,
+        'BA_Sb': basal_area_sb,
+        'SDF_Aw': sdf_aw0,
+        'SDF_Sw': sdf_sw0,
+        'SDF_Pl': sdf_pl0,
+        'SDF_Sb': sdf_sb0,
+        'N0_Aw': initial_density_aw,
+        'N0_Sb': initial_density_sb,
+        'N0_Sw': initial_density_sw,
+        'N0_Pl': initial_density_pl,
+        'StumpDOB_Aw': species_dict['Aw']['StumpDOB'],
+        'StumpDOB_Sb': species_dict['Sb']['StumpDOB'],
+        'StumpDOB_Sw': species_dict['Sw']['StumpDOB'],
+        'StumpDOB_Pl': species_dict['Pl']['StumpDOB'],
+        'StumpHeight_Aw': species_dict['Aw']['StumpHeight'],
+        'StumpHeight_Sb': species_dict['Sb']['StumpHeight'],
+        'Stumpheight_Sw': species_dict['Sw']['StumpHeight'],
+        'StumpHeight_Pl': species_dict['Pl']['StumpHeight'],
+        'TopDib_Aw': species_dict['Aw']['TopDib'],
+        'TopDib_Sb': species_dict['Sb']['TopDib'],
+        'TopDib_Sw': species_dict['Sw']['TopDib'],
+        'TopDib_Pl': species_dict['Pl']['TopDib'],
+        'topHeight_Aw': top_height_aw,
+        'topHeight_Sw': top_height_sw,
+        'topHeight_Sb': top_height_sb,
+        'topHeight_Pl': top_height_pl
+    }
+
+    return plot_properties
+
+
+def prep_standtable(data, **kwargs):
     '''Define site_index of all other species given the dominant species
 
     The site index is only defined for the dominant species in a plot. This
@@ -142,192 +324,24 @@ def prep_standtable(data, minimum_age=25):
     - calculate the SIs for other species from the conversion formulas
 
     :param data: input data frame
-
+    :param kwargs: additional arguments to :func:`_prep_row`
     '''
     plot_dict = {}
     n_rows = data.shape[0]
+
     for i, row in data.iterrows():
         _log_loop_progress(i, n_rows)
-
-        # from the row, compile a list of species abbreviation and percents
-        species_abbrev_percent_list = [
-            (row['SP1'], row['PCT1']),
-            (row['SP2'], row['PCT2']),
-            (row['SP3'], row['PCT3']),
-            (row['SP4'], row['PCT4']),
-            (row['SP5'], row['PCT5'])
-        ]
-
-        # validate species percents add to 100
-        check_prop = sum(zip(*species_abbrev_percent_list)[1])
-        if check_prop != 100:
-            raise ValueError('Species proportions not correct: %s' % check_prop)
-
-        # pull some key vaiables off the row
         plot_id = row['id_l1']
-        plot_dominant_species = row['SP1']
-        dominant_species_current_age = row['AGE']
-        dominant_species_current_height = row['HD']
 
-        if dominant_species_current_age < minimum_age:
-            msg = ('Dominant species age is less than minimum age %s;'
-                   'skipping plot %s') % (minimum_age, plot_id)
-            LOGGER.warning(msg)
-            continue
-
-        site_index = _estimate_site_index(
-            plot_dominant_species,
-            dominant_species_current_age,
-            dominant_species_current_height
-        )
-
-        temp_dominant_species = _get_gypsy_valid_species(plot_dominant_species)
-        gypsy_site_indices = get_site_indices_from_dominant_species(
-            temp_dominant_species,
-            site_index
-        )
-        empty_species_dict = _generate_fplot_dict()
-        species_dict = _populate_species_dict_with_indices(empty_species_dict,
-                                                           gypsy_site_indices)
-
-        outer_sorted_species_perc_list, outer_species_perc_dict = \
-            _reclassify_and_sort_species(species_abbrev_percent_list)
-
-        species_dict['Aw']['PCT'] = outer_species_perc_dict['Aw']
-        species_dict['Pl']['PCT'] = outer_species_perc_dict['Pl']
-        species_dict['Sw']['PCT'] = outer_species_perc_dict['Sw']
-        species_dict['Sb']['PCT'] = outer_species_perc_dict['Sb']
-
-        dominant_species = outer_sorted_species_perc_list[0]
-
-        species_dict = populate_species_dict(
-            species_dict, outer_sorted_species_perc_list,
-            dominant_species=dominant_species,
-            row=row,
-            dominant_species_current_age=dominant_species_current_age,
-            dominant_species_current_height=dominant_species_current_height
-        )
-
-        density_aw = species_dict['Aw']['N']
-        density_sw = species_dict['Sw']['N']
-        density_pl = species_dict['Pl']['N']
-        density_sb = species_dict['Sb']['N']
-
-        tage_aw = species_dict['Aw']['tage']
-        tage_sw = species_dict['Sw']['tage']
-        tage_pl = species_dict['Pl']['tage']
-        tage_sb = species_dict['Sb']['tage']
-
-        bhage_aw = species_dict['Aw']['bhage']
-        bhage_sw = species_dict['Sw']['bhage']
-        bhage_pl = species_dict['Pl']['bhage']
-        bhage_sb = species_dict['Sb']['bhage']
-
-        y2bh_aw = tage_aw - bhage_aw
-        y2bh_sw = tage_sw - bhage_sw
-        y2bh_pl = tage_pl - bhage_pl
-        y2bh_sb = tage_sb - bhage_sb
-
-        site_index_aw = species_dict['Aw']['SI']
-        site_index_sw = species_dict['Sw']['SI']
-        site_index_pl = species_dict['Pl']['SI']
-        site_index_sb = species_dict['Sb']['SI']
-
-        basal_area_aw = species_dict['Aw']['BA']
-        basal_area_sb = species_dict['Sb']['BA']
-        basal_area_sw = species_dict['Sw']['BA']
-        basal_area_pl = species_dict['Pl']['BA']
-
-        # Top height for all species
-        top_height_aw = ComputeGypsyTreeHeightGivenSiteIndexAndTotalAge(
-            'Aw', site_index_aw, tage_aw
-        )
-        top_height_sb = ComputeGypsyTreeHeightGivenSiteIndexAndTotalAge(
-            'Sb', site_index_sb, tage_sb
-        )
-        top_height_pl = ComputeGypsyTreeHeightGivenSiteIndexAndTotalAge(
-            'Pl', site_index_pl, tage_pl
-        )
-        top_height_sw = ComputeGypsyTreeHeightGivenSiteIndexAndTotalAge(
-            'Sw', site_index_sw, tage_sw
-        )
-
-        # stand desnity factor for all species
-        y_aw = estimate_sdf_aw('Aw', site_index_aw, bhage_aw, density_aw)
-        sdf_aw0 = y_aw[1]
-        density_bh_aw = y_aw[0]
-
-        y_sb = estimate_sdf_sb('Sb', site_index_sb, tage_sb, density_sb)
-        sdf_sb0 = y_sb[1]
-        density_bh_sb = y_sb[0]
-
-        y_sw = estimate_sdf_sw('Sw', site_index_sw, tage_sw, sdf_aw0, density_sw)
-        sdf_sw0 = y_sw[1]
-        density_bh_sw = y_sw[0]
-
-        y_pl = estimate_sdf_pl(
-            'Pl', site_index_pl, tage_pl,
-            sdf_aw0, sdf_sw0, sdf_sb0, density_pl
-        )
-        sdf_pl0 = y_pl[1]
-        density_bh_pl = y_pl[0]
-
-        # estimating species densities at time zero
-        initial_density_aw = estimate_density_aw(sdf_aw0, 0, site_index_aw)
-        initial_density_sb = estimate_density_sb(sdf_sb0, 0, site_index_sb)
-        initial_density_sw = estimate_density_sw(
-            sdf_sw0, sdf_aw0, 0, site_index_sw
-        )
-        initial_density_pl = estimate_density_pl(
-            sdf_aw0, sdf_sw0, sdf_sb0, sdf_pl0, 0, site_index_pl
-        )
-
-        plot_dict[plot_id] = {
-            'SI_Aw': site_index_aw,
-            'SI_Sw': site_index_sw,
-            'SI_Pl': site_index_pl,
-            'SI_Sb': site_index_sb,
-            'N_Aw': density_aw,
-            'N_Sw': density_sw,
-            'N_Pl': density_pl,
-            'N_Sb': density_sb,
-            'y2bh_Aw': y2bh_aw,
-            'y2bh_Sw': y2bh_sw,
-            'y2bh_Pl': y2bh_pl,
-            'y2bh_Sb': y2bh_sb,
-            'tage_Aw': tage_aw,
-            'tage_Sw': tage_sw,
-            'tage_Pl': tage_pl,
-            'tage_Sb': tage_sb,
-            'BA_Aw': basal_area_aw,
-            'BA_Sw': basal_area_sw,
-            'BA_Pl': basal_area_pl,
-            'BA_Sb': basal_area_sb,
-            'SDF_Aw': sdf_aw0,
-            'SDF_Sw': sdf_sw0,
-            'SDF_Pl': sdf_pl0,
-            'SDF_Sb': sdf_sb0,
-            'N0_Aw': initial_density_aw,
-            'N0_Sb': initial_density_sb,
-            'N0_Sw': initial_density_sw,
-            'N0_Pl': initial_density_pl,
-            'StumpDOB_Aw': species_dict['Aw']['StumpDOB'],
-            'StumpDOB_Sb': species_dict['Sb']['StumpDOB'],
-            'StumpDOB_Sw': species_dict['Sw']['StumpDOB'],
-            'StumpDOB_Pl': species_dict['Pl']['StumpDOB'],
-            'StumpHeight_Aw': species_dict['Aw']['StumpHeight'],
-            'StumpHeight_Sb': species_dict['Sb']['StumpHeight'],
-            'Stumpheight_Sw': species_dict['Sw']['StumpHeight'],
-            'StumpHeight_Pl': species_dict['Pl']['StumpHeight'],
-            'TopDib_Aw': species_dict['Aw']['TopDib'],
-            'TopDib_Sb': species_dict['Sb']['TopDib'],
-            'TopDib_Sw': species_dict['Sw']['TopDib'],
-            'TopDib_Pl': species_dict['Pl']['TopDib'],
-            'topHeight_Aw': top_height_aw,
-            'topHeight_Sw': top_height_sw,
-            'topHeight_Sb': top_height_sb,
-            'topHeight_Pl': top_height_pl
-        }
+        try:
+            prepped_plot = _prep_row(row, **kwargs)
+            plot_dict[plot_id] = prepped_plot
+        except MinimumAgeError as err:
+            LOGGER.error(err.message)
+        except ProportionsSumError as err:
+            LOGGER.error(err.message)
+        except Exception as err: #pylint: disable=broad-except
+            LOGGER.critical('Unhandled error: %s', err.message)
 
     plot_df = pd.DataFrame(plot_dict)
     plot_df = plot_df.transpose()

--- a/pygypsy/exceptions.py
+++ b/pygypsy/exceptions.py
@@ -1,0 +1,5 @@
+class MinimumAgeError(ValueError):
+    pass
+
+class ProportionsSumError(ValueError):
+    pass

--- a/pygypsy/forward_simulation.py
+++ b/pygypsy/forward_simulation.py
@@ -376,7 +376,7 @@ def _simulate_row(row, utiliz_params=None, n_years=250, backwards=True,
     output_df.reset_index(inplace=True)
     output_df = output_df.rename(columns={'index': 'year'})
     output_df['year'] = output_df['year'] + year_of_data_acquisition + 1
-    output_df['plot_id'] = int(row['id_l1'])
+    output_df['id_l1'] = int(row['id_l1'])
 
     return output_df
 
@@ -433,6 +433,6 @@ def simulate_forwards_df(plot_df, **kwargs):
                      duration.total_seconds())
 
     complete_output_df = pd.concat(output_dict.values(), copy=False)
-    complete_output_df.set_index(['plot_id', 'year'], inplace=True)
+    complete_output_df.set_index(['id_l1', 'year'], inplace=True)
 
     return complete_output_df

--- a/pygypsy/forward_simulation.py
+++ b/pygypsy/forward_simulation.py
@@ -187,8 +187,201 @@ def simulate_densities_speciescomp_topheight(n_years=250, start_at_data_year=Fal
     return densities_along_time
 
 
-def simulate_forwards_df(plot_df, utiliz_params=None, backwards=True,
-                         n_years=250, year_of_data_acquisition=0):
+def _simulate_row(row, utiliz_params=None, n_years=250, backwards=True,
+                  year_of_data_acquisition=0):
+    """ Simulate a single plot
+
+    :param row: row of pandas data frame
+    :param utliz_params: dictionary of utilization parameters
+    :param int n_years: number of years to simulate
+    :param bool backwards: whether the simulation from year zero to the
+                           year of the data should be done
+    :param year_of_data_acquisition: year in which data was acquired, used
+                                     to set year index
+
+    .. note: access a single row like df.ix[row, ]
+    """
+    if utiliz_params is None:
+        utiliz_params = DEFAULT_UTILIZATIONS
+
+    SI_bh_Aw = row.at['SI_Aw']
+    SI_bh_Sw = row.at['SI_Sw']
+    SI_bh_Pl = row.at['SI_Pl']
+    SI_bh_Sb = row.at['SI_Sb']
+    N_bh_AwT = row.at['N_Aw']
+    N_bh_SwT = row.at['N_Sw']
+    N_bh_PlT = row.at['N_Pl']
+    N_bh_SbT = row.at['N_Sb']
+    y2bh_Aw = row.at['y2bh_Aw']
+    y2bh_Sw = row.at['y2bh_Sw']
+    y2bh_Sb = row.at['y2bh_Sb']
+    y2bh_Pl = row.at['y2bh_Pl']
+    tage_AwT = row.at['tage_Aw']
+    tage_SwT = row.at['tage_Sw']
+    tage_PlT = row.at['tage_Pl']
+    tage_SbT = row.at['tage_Sb']
+    BA_AwT = row.at['BA_Aw']
+    BA_SwT = row.at['BA_Sw']
+    BA_PlT = row.at['BA_Pl']
+    BA_SbT = row.at['BA_Sb']
+    SDF_Aw0 = row.at['SDF_Aw']
+    SDF_Sw0 = row.at['SDF_Sw']
+    SDF_Pl0 = row.at['SDF_Pl']
+    SDF_Sb0 = row.at['SDF_Sb']
+    N0_Aw = row.at['N0_Aw']
+    N0_Sw = row.at['N0_Sw']
+    N0_Pl = row.at['N0_Pl']
+    N0_Sb = row.at['N0_Sb']
+
+    BA_Aw0 = _get_initial_basal_area(BA_AwT)
+    BA_Sw0 = _get_initial_basal_area(BA_SwT)
+    BA_Sb0 = _get_initial_basal_area(BA_SbT)
+    BA_Pl0 = _get_initial_basal_area(BA_PlT)
+
+    SC_Aw, SC_Sw, SC_Sb, SC_Pl = estimate_species_composition(
+        N0_Aw, N0_Sb, N0_Sw, N0_Pl
+    )
+
+    tageData = [tage_AwT, tage_SwT, tage_PlT, tage_SbT]
+    startTageAw = tageData[0]
+    startTageSw = tageData[1]
+    startTagePl = tageData[2]
+    startTageSb = tageData[3]
+
+    tageData = sorted(tageData, reverse=True)
+    startTage = int(tageData[0])
+
+    densities = simulate_densities_speciescomp_topheight(
+        n_years=n_years,
+        start_at_data_year=False if backwards else True,
+        startTage=startTage,
+        startTageAw=startTageAw,
+        y2bh_Aw=y2bh_Aw,
+        startTageSw=startTageSw,
+        y2bh_Sw=y2bh_Sw,
+        startTageSb=startTageSb,
+        y2bh_Sb=y2bh_Sb,
+        startTagePl=startTagePl,
+        y2bh_Pl=y2bh_Pl,
+        SDF_Aw0=SDF_Aw0,
+        SDF_Sw0=SDF_Sw0,
+        SDF_Pl0=SDF_Pl0,
+        SDF_Sb0=SDF_Sb0,
+        SI_bh_Aw=SI_bh_Aw,
+        SI_bh_Sw=SI_bh_Sw,
+        SI_bh_Sb=SI_bh_Sb,
+        SI_bh_Pl=SI_bh_Pl
+    )
+
+    species_factors = defaultdict(lambda: 1) if not backwards else \
+                      get_basal_area_factors_for_all_species(
+                          startTage=startTage,
+                          startTageAw=startTageAw, startTageSb=startTageSb,
+                          startTageSw=startTageSw, startTagePl=startTagePl,
+                          y2bh_Aw=y2bh_Aw, y2bh_Sb=y2bh_Sb,
+                          y2bh_Sw=y2bh_Sw, y2bh_Pl=y2bh_Pl,
+                          SC_Aw=SC_Aw, SC_Sb=SC_Sb, SC_Sw=SC_Sw, SC_Pl=SC_Pl,
+                          SI_bh_Aw=SI_bh_Aw, SI_bh_Sb=SI_bh_Sb,
+                          SI_bh_Sw=SI_bh_Sw, SI_bh_Pl=SI_bh_Pl,
+                          N_bh_AwT=N_bh_AwT, N_bh_SbT=N_bh_SbT,
+                          N_bh_SwT=N_bh_SwT, N_bh_PlT=N_bh_PlT,
+                          N0_Aw=N0_Aw, N0_Sb=N0_Sb, N0_Sw=N0_Sw, N0_Pl=N0_Pl,
+                          BA_Aw0=BA_Aw0, BA_Sb0=BA_Sb0,
+                          BA_Sw0=BA_Sw0, BA_Pl0=BA_Pl0,
+                          BA_AwT=BA_AwT, BA_SbT=BA_SbT,
+                          BA_SwT=BA_SwT, BA_PlT=BA_PlT,
+                          SDF_Pl0=SDF_Pl0, SDF_Sb0=SDF_Sb0,
+                          SDF_Aw0=SDF_Aw0, SDF_Sw0=SDF_Sw0,
+                          densities=densities
+                      )
+
+    # use_correction_factor_future here is True because aspen was peculiar,
+    # empirically demonstrated that using the factor for the whole
+    # simulation yielded better results, probably because of variability in
+    # density and basal area unique to aspen
+    basal_area_aw_arr = sim_basal_area_aw(
+        startTage, SI_bh_Aw, N0_Aw, BA_Aw0, SDF_Aw0,
+        species_factors['f_Aw'], densities,
+        use_correction_factor_future=True if backwards else False,
+        stop_at_initial_age=False,
+        force_use_densities=False if backwards else True
+    )
+    basal_area_sb_arr = sim_basal_area_sb(
+        startTage, SI_bh_Sb, N0_Sb, BA_Sb0,
+        species_factors['f_Sb'], densities,
+        use_correction_factor_future=False, stop_at_initial_age=False,
+        fix_proportion_and_density_to_initial_age=False,
+        species_proportion_at_bh_age=SC_Sb, present_density=N_bh_SbT,
+        force_use_densities=False if backwards else True
+    )
+    basal_area_sw_arr = sim_basal_area_sw(
+        startTage, SI_bh_Sw, N0_Sw, SDF_Aw0, SDF_Pl0, SDF_Sb0, BA_Sw0,
+        species_factors['f_Sw'], densities,
+        use_correction_factor_future=False, stop_at_initial_age=False,
+        fix_proportion_and_density_to_initial_age=False,
+        species_proportion_at_bh_age=SC_Sw, present_density=N_bh_SwT,
+        force_use_densities=False if backwards else True
+    )
+    basal_area_pl_arr = sim_basal_area_pl(
+        startTage, SI_bh_Pl, N0_Pl, SDF_Aw0, SDF_Sw0, SDF_Sb0, BA_Pl0,
+        species_factors['f_Pl'], densities,
+        use_correction_factor_future=False, stop_at_initial_age=False,
+        fix_proportion_and_density_to_initial_age=False,
+        species_proportion_at_bh_age=SC_Pl, present_density=N_bh_PlT,
+        force_use_densities=False if backwards else True
+    )
+
+    output_df_aw = pd.DataFrame(basal_area_aw_arr, columns=['BA_Aw'])
+    output_df_sw = pd.DataFrame(basal_area_sw_arr, columns=['BA_Sw'])
+    output_df_sb = pd.DataFrame(basal_area_sb_arr, columns=['BA_Sb'])
+    output_df_pl = pd.DataFrame(basal_area_pl_arr, columns=['BA_Pl'])
+
+    densities_df = pd.DataFrame(densities)
+    output_df = pd.concat(
+        [densities_df, output_df_aw, output_df_sw, output_df_sb, output_df_pl],
+        axis=1
+    )
+
+    for spec in SPECIES:
+        output_df['Gross_Total_Volume_%s' % spec] = gross_total_volume(
+            spec,
+            output_df['BA_%s' % spec],
+            output_df['topHeight_%s' % spec]
+        )
+
+        output_df['MerchantableVolume%s' % spec] = merchantable_volume(
+            spec,
+            output_df['N_bh_%sT' % spec],
+            output_df['BA_%s' % spec],
+            output_df['topHeight_%s' % spec],
+            output_df['Gross_Total_Volume_%s' % spec],
+            top_dib=utiliz_params[spec.lower()]['topDiamInsideBark'],
+            stump_dob=utiliz_params[spec.lower()]['stumpDiamOutsideBark'],
+            stump_height=utiliz_params[spec.lower()]['stumpHeight']
+        )
+
+    output_df['Gross_Total_Volume_Con'] = output_df['Gross_Total_Volume_Sw'] \
+                                          + output_df['Gross_Total_Volume_Sb'] \
+                                          + output_df['Gross_Total_Volume_Pl']
+    output_df['Gross_Total_Volume_Dec'] = output_df['Gross_Total_Volume_Aw']
+    output_df['Gross_Total_Volume_Tot'] = output_df['Gross_Total_Volume_Con'] \
+                                          + output_df['Gross_Total_Volume_Dec']
+    output_df['MerchantableVolume_Con'] = output_df['MerchantableVolumeSw'] \
+                                          + output_df['MerchantableVolumeSb'] \
+                                          + output_df['MerchantableVolumePl']
+    output_df['MerchantableVolume_Dec'] = output_df['MerchantableVolumeAw']
+    output_df['MerchantableVolume_Tot'] = output_df['MerchantableVolume_Con'] \
+                                          + output_df['MerchantableVolume_Dec']
+
+    output_df.reset_index(inplace=True)
+    output_df = output_df.rename(columns={'index': 'year'})
+    output_df['year'] = output_df['year'] + year_of_data_acquisition + 1
+    output_df['plot_id'] = int(row['id_l1'])
+
+    return output_df
+
+
+def simulate_forwards_df(plot_df, **kwargs):
     """Simulate the evolution of plot characteristics through time
 
     This begins with the simulation of densities, species, and top height.
@@ -207,13 +400,10 @@ def simulate_forwards_df(plot_df, utiliz_params=None, backwards=True,
     functions, instead of using fixed values.
 
     :param plot_df: pandas.DataFrame with plot data
-    :param utliz_params: dictionary of utilization parameters
-    :param int n_years: number of years to simulate
-    :param bool backwards: whether the simulation from year zero to the
-                           year of the data should be done
+    :param kwargs: keyword arguments to func:`_simulate_row`
 
-    :return: dictoriony with keys corresponding to plot id and values data
-    frame of time  series of the simulated plot characteristics
+    :return: multi-index data frame with plot id and year as index and values
+    of the simulated plot characteristics
 
     .. warning:: the backwards parameter must be set to True in order to
                  utilize the correction factors, which ensure the data passes
@@ -222,9 +412,6 @@ def simulate_forwards_df(plot_df, utiliz_params=None, backwards=True,
                  is also used for the forward simulation
 
     """
-    if utiliz_params is None:
-        utiliz_params = DEFAULT_UTILIZATIONS
-
     output_dict = {}
     n_rows = plot_df.shape[0]
 
@@ -232,180 +419,18 @@ def simulate_forwards_df(plot_df, utiliz_params=None, backwards=True,
         start = datetime.datetime.now()
         _log_loop_progress(_, n_rows)
         plot_id = str(int(row['id_l1']))
-
         LOGGER.debug('Starting simulation for plot: %s', plot_id)
-        SI_bh_Aw = row.at['SI_Aw']
-        SI_bh_Sw = row.at['SI_Sw']
-        SI_bh_Pl = row.at['SI_Pl']
-        SI_bh_Sb = row.at['SI_Sb']
-        N_bh_AwT = row.at['N_Aw']
-        N_bh_SwT = row.at['N_Sw']
-        N_bh_PlT = row.at['N_Pl']
-        N_bh_SbT = row.at['N_Sb']
-        y2bh_Aw = row.at['y2bh_Aw']
-        y2bh_Sw = row.at['y2bh_Sw']
-        y2bh_Sb = row.at['y2bh_Sb']
-        y2bh_Pl = row.at['y2bh_Pl']
-        tage_AwT = row.at['tage_Aw']
-        tage_SwT = row.at['tage_Sw']
-        tage_PlT = row.at['tage_Pl']
-        tage_SbT = row.at['tage_Sb']
-        BA_AwT = row.at['BA_Aw']
-        BA_SwT = row.at['BA_Sw']
-        BA_PlT = row.at['BA_Pl']
-        BA_SbT = row.at['BA_Sb']
-        SDF_Aw0 = row.at['SDF_Aw']
-        SDF_Sw0 = row.at['SDF_Sw']
-        SDF_Pl0 = row.at['SDF_Pl']
-        SDF_Sb0 = row.at['SDF_Sb']
-        N0_Aw = row.at['N0_Aw']
-        N0_Sw = row.at['N0_Sw']
-        N0_Pl = row.at['N0_Pl']
-        N0_Sb = row.at['N0_Sb']
 
-        BA_Aw0 = _get_initial_basal_area(BA_AwT)
-        BA_Sw0 = _get_initial_basal_area(BA_SwT)
-        BA_Sb0 = _get_initial_basal_area(BA_SbT)
-        BA_Pl0 = _get_initial_basal_area(BA_PlT)
-
-        SC_Aw, SC_Sw, SC_Sb, SC_Pl = estimate_species_composition(
-            N0_Aw, N0_Sb, N0_Sw, N0_Pl
-        )
-
-        tageData = [tage_AwT, tage_SwT, tage_PlT, tage_SbT]
-        startTageAw = tageData[0]
-        startTageSw = tageData[1]
-        startTagePl = tageData[2]
-        startTageSb = tageData[3]
-
-        tageData = sorted(tageData, reverse=True)
-        startTage = int(tageData[0])
-
-        densities = simulate_densities_speciescomp_topheight(
-            n_years=n_years,
-            start_at_data_year=False if backwards else True,
-            startTage=startTage,
-            startTageAw=startTageAw,
-            y2bh_Aw=y2bh_Aw,
-            startTageSw=startTageSw,
-            y2bh_Sw=y2bh_Sw,
-            startTageSb=startTageSb,
-            y2bh_Sb=y2bh_Sb,
-            startTagePl=startTagePl,
-            y2bh_Pl=y2bh_Pl,
-            SDF_Aw0=SDF_Aw0,
-            SDF_Sw0=SDF_Sw0,
-            SDF_Pl0=SDF_Pl0,
-            SDF_Sb0=SDF_Sb0,
-            SI_bh_Aw=SI_bh_Aw,
-            SI_bh_Sw=SI_bh_Sw,
-            SI_bh_Sb=SI_bh_Sb,
-            SI_bh_Pl=SI_bh_Pl
-        )
-
-        species_factors = defaultdict(lambda: 1) if not backwards else \
-                          get_basal_area_factors_for_all_species(
-            startTage=startTage,
-            startTageAw=startTageAw, startTageSb=startTageSb,
-            startTageSw=startTageSw, startTagePl=startTagePl,
-            y2bh_Aw=y2bh_Aw, y2bh_Sb=y2bh_Sb, y2bh_Sw=y2bh_Sw, y2bh_Pl=y2bh_Pl,
-            SC_Aw=SC_Aw, SC_Sb=SC_Sb, SC_Sw=SC_Sw, SC_Pl=SC_Pl,
-            SI_bh_Aw=SI_bh_Aw, SI_bh_Sb=SI_bh_Sb, SI_bh_Sw=SI_bh_Sw, SI_bh_Pl=SI_bh_Pl,
-            N_bh_AwT=N_bh_AwT, N_bh_SbT=N_bh_SbT, N_bh_SwT=N_bh_SwT, N_bh_PlT=N_bh_PlT,
-            N0_Aw=N0_Aw, N0_Sb=N0_Sb, N0_Sw=N0_Sw, N0_Pl=N0_Pl,
-            BA_Aw0=BA_Aw0, BA_Sb0=BA_Sb0, BA_Sw0=BA_Sw0, BA_Pl0=BA_Pl0,
-            BA_AwT=BA_AwT, BA_SbT=BA_SbT, BA_SwT=BA_SwT, BA_PlT=BA_PlT,
-            SDF_Pl0=SDF_Pl0, SDF_Sb0=SDF_Sb0, SDF_Aw0=SDF_Aw0, SDF_Sw0=SDF_Sw0,
-            densities=densities
-        )
-
-        # use_correction_factor_future here is True because aspen was peculiar,
-        # empirically demonstrated that using the factor for the whole
-        # simulation yielded better results, probably because of variability in
-        # density and basal area unique to aspen
-        basal_area_aw_arr = sim_basal_area_aw(
-            startTage, SI_bh_Aw, N0_Aw, BA_Aw0, SDF_Aw0,
-            species_factors['f_Aw'], densities,
-            use_correction_factor_future=True if backwards else False,
-            stop_at_initial_age=False,
-            force_use_densities=False if backwards else True
-        )
-        basal_area_sb_arr = sim_basal_area_sb(
-            startTage, SI_bh_Sb, N0_Sb, BA_Sb0,
-            species_factors['f_Sb'], densities,
-            use_correction_factor_future=False, stop_at_initial_age=False,
-            fix_proportion_and_density_to_initial_age=False,
-            species_proportion_at_bh_age=SC_Sb, present_density=N_bh_SbT,
-            force_use_densities=False if backwards else True
-        )
-        basal_area_sw_arr = sim_basal_area_sw(
-            startTage, SI_bh_Sw, N0_Sw, SDF_Aw0, SDF_Pl0, SDF_Sb0, BA_Sw0,
-            species_factors['f_Sw'], densities,
-            use_correction_factor_future=False, stop_at_initial_age=False,
-            fix_proportion_and_density_to_initial_age=False,
-            species_proportion_at_bh_age=SC_Sw, present_density=N_bh_SwT,
-            force_use_densities=False if backwards else True
-        )
-        basal_area_pl_arr = sim_basal_area_pl(
-            startTage, SI_bh_Pl, N0_Pl, SDF_Aw0, SDF_Sw0, SDF_Sb0, BA_Pl0,
-            species_factors['f_Pl'], densities,
-            use_correction_factor_future=False, stop_at_initial_age=False,
-            fix_proportion_and_density_to_initial_age=False,
-            species_proportion_at_bh_age=SC_Pl, present_density=N_bh_PlT,
-            force_use_densities=False if backwards else True
-        )
-
-        output_df_aw = pd.DataFrame(basal_area_aw_arr, columns=['BA_Aw'])
-        output_df_sw = pd.DataFrame(basal_area_sw_arr, columns=['BA_Sw'])
-        output_df_sb = pd.DataFrame(basal_area_sb_arr, columns=['BA_Sb'])
-        output_df_pl = pd.DataFrame(basal_area_pl_arr, columns=['BA_Pl'])
-
-        densities_df = pd.DataFrame(densities)
-        output_df = pd.concat(
-            [densities_df, output_df_aw, output_df_sw, output_df_sb, output_df_pl],
-            axis=1
-        )
-
-        for spec in SPECIES:
-            output_df['Gross_Total_Volume_%s' % spec] = gross_total_volume(
-                spec,
-                output_df['BA_%s' % spec],
-                output_df['topHeight_%s' % spec]
-            )
-
-            output_df['MerchantableVolume%s' % spec] = merchantable_volume(
-                spec,
-                output_df['N_bh_%sT' % spec],
-                output_df['BA_%s' % spec],
-                output_df['topHeight_%s' % spec],
-                output_df['Gross_Total_Volume_%s' % spec],
-                top_dib=utiliz_params[spec.lower()]['topDiamInsideBark'],
-                stump_dob=utiliz_params[spec.lower()]['stumpDiamOutsideBark'],
-                stump_height=utiliz_params[spec.lower()]['stumpHeight']
-            )
-
-        output_df['Gross_Total_Volume_Con'] = output_df['Gross_Total_Volume_Sw'] \
-                                              + output_df['Gross_Total_Volume_Sb'] \
-                                              + output_df['Gross_Total_Volume_Pl']
-        output_df['Gross_Total_Volume_Dec'] = output_df['Gross_Total_Volume_Aw']
-        output_df['Gross_Total_Volume_Tot'] = output_df['Gross_Total_Volume_Con'] \
-                                              + output_df['Gross_Total_Volume_Dec']
-        output_df['MerchantableVolume_Con'] = output_df['MerchantableVolumeSw'] \
-                                              + output_df['MerchantableVolumeSb'] \
-                                              + output_df['MerchantableVolumePl']
-        output_df['MerchantableVolume_Dec'] = output_df['MerchantableVolumeAw']
-        output_df['MerchantableVolume_Tot'] = output_df['MerchantableVolume_Con'] \
-                                              + output_df['MerchantableVolume_Dec']
-
-        output_df.reset_index(inplace=True)
-        output_df = output_df.rename(columns={'index': 'year'})
-        output_df['year'] = output_df['year'] + year_of_data_acquisition + 1
-        output_df['plot_id'] = plot_id
-        output_dict[plot_id] = output_df
+        try:
+            output_df = _simulate_row(row, **kwargs)
+            output_dict[plot_id] = output_df
+        except Exception as err: #pylint: disable=broad-except
+            LOGGER.critical('Unhandled error: %s', err.message)
 
         end = datetime.datetime.now()
         duration = end - start
-        LOGGER.debug('plot %s took %f seconds', plot_id, duration.total_seconds())
+        LOGGER.debug('plot %s took %f seconds', plot_id,
+                     duration.total_seconds())
 
     complete_output_df = pd.concat(output_dict.values(), copy=False)
     complete_output_df.set_index(['plot_id', 'year'], inplace=True)

--- a/pygypsy/scripts/cli.py
+++ b/pygypsy/scripts/cli.py
@@ -154,7 +154,6 @@ def simulate(ctx, data, config_file):
     bucket_name = ctx.obj['s3-bucket-name']
     bucket_conn = ctx.obj['s3-bucket-conn']
     output_dir = ctx.obj['output-dir']
-    index_label = 'id_l1'
 
     try:
         standtable = pd.read_csv(data)
@@ -175,10 +174,9 @@ def simulate(ctx, data, config_file):
             filename = '%s.csv' % year_or_plot
             output_path = os.path.join(simulation_output_dir, filename)
             if bucket_name:
-                df_to_s3_bucket(data, bucket_conn, output_path,
-                                index_label=index_label)
+                df_to_s3_bucket(data, bucket_conn, output_path)
             else:
-                data.to_csv(output_path, index_label=index_label)
+                data.to_csv(output_path)
     except:
         _copy_file(LOG_FILE_NAME, gyppath._join(output_dir, 'simulate.log'),
                    bucket_conn)

--- a/tests/test_data_prep.py
+++ b/tests/test_data_prep.py
@@ -1,8 +1,11 @@
+#pylint: disable=missing-docstring,invalid-name
 import os
+import pytest
 import pandas as pd
 import numpy.testing as npt
 
-from pygypsy.data_prep import prep_standtable
+from pygypsy.data_prep import prep_standtable, _prep_row
+from pygypsy.exceptions import MinimumAgeError, ProportionsSumError
 
 from conftest import DATA_DIR
 
@@ -40,3 +43,20 @@ def test_prep_omits_all_plots():
     result = prep_standtable(plot_data, minimum_age=5000)
 
     assert result.shape[0] == 0
+
+def test_prep_row_raises_minimum_age_error():
+    data_file_name = 'raw_standtable.csv'
+    plot_data = pd.read_csv(os.path.join(DATA_DIR, data_file_name))
+
+    with pytest.raises(MinimumAgeError) as err:
+        _prep_row(plot_data.ix[0,], minimum_age=5000)
+    assert 'age' in str(err.value)
+
+def test_prep_row_raises_proportion_error():
+    data_file_name = 'raw_standtable.csv'
+    plot_data = pd.read_csv(os.path.join(DATA_DIR, data_file_name))
+    plot_data.loc[0,'PCT1'] = 10
+
+    with pytest.raises(ProportionsSumError) as err:
+        _prep_row(plot_data.ix[0,])
+    assert 'proportions do not add to 1' in str(err.value)


### PR DESCRIPTION
closes #76 

Refactors prep_standtable contents into a function that operates on rows
and raises an error if the plot data is problematic
Prep standtable function now just handles the logic around coordinating
the work done on each row and delegates to the _prep_row function
Added tests for the exceptions raised by _prep_row

Similar refactor for the simulation into a function that operates on rows

Users will ideally clean data before running gypsy, but this way we can run on all of their plots and have a report of errors for problematic plots (which they probably did not intend to simulate in the first place).